### PR TITLE
feat: limit response size

### DIFF
--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/HttpEntities.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/HttpEntities.java
@@ -19,8 +19,8 @@ final class HttpEntities {
         byte[] getBody();
     }
 
-    Copy copy(final HttpEntity entity) throws IOException {
-        final byte[] body = toByteArray(entity);
+    Copy copy(final HttpEntity entity, int sizeLimit) throws IOException {
+        final byte[] body = toByteArray(entity, sizeLimit);
         ContentType contentType = ContentType.parse(entity.getContentType());
         boolean chunked = entity.isChunked();
         String contentEncoding = entity.getContentEncoding();

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LocalRequest.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LocalRequest.java
@@ -76,7 +76,7 @@ final class LocalRequest implements org.zalando.logbook.HttpRequest {
                 if (httpEntity == null) {
                     return new Passing();
                 } else {
-                    final HttpEntities.Copy copy = HttpEntities.copy(httpEntity);
+                    final HttpEntities.Copy copy = HttpEntities.copy(httpEntity, Integer.MAX_VALUE);
                     original.setEntity(copy);
                     return new Buffering(copy.getBody());
                 }

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumer.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpAsyncResponseConsumer.java
@@ -46,7 +46,7 @@ public final class LogbookHttpAsyncResponseConsumer<T> extends ForwardingHttpAsy
 
     @Override
     public void consume(ByteBuffer src) throws IOException {
-        stage.process(new RemoteResponse(this.response, this.entityDetails, src)).write();
+        stage.process(new RemoteResponse(this.response, this.entityDetails, src, Integer.MAX_VALUE)).write();
         delegate().consume(src);
     }
 

--- a/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpResponseInterceptor.java
+++ b/logbook-httpclient5/src/main/java/org/zalando/logbook/httpclient5/LogbookHttpResponseInterceptor.java
@@ -21,11 +21,19 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
  */
 @API(status = EXPERIMENTAL)
 public final class LogbookHttpResponseInterceptor implements HttpResponseInterceptor {
+    final int maxResponseSize;
+    public LogbookHttpResponseInterceptor() {
+        maxResponseSize = Integer.MAX_VALUE;
+    }
+
+    public LogbookHttpResponseInterceptor(int maxResponseSize) {
+        this.maxResponseSize = maxResponseSize;
+    }
 
     @Override
     public void process(HttpResponse original, EntityDetails entity, HttpContext context) throws IOException {
         final ResponseProcessingStage stage = find(context);
-        stage.process(new RemoteResponse(original)).write();
+        stage.process(new RemoteResponse(original, maxResponseSize)).write();
     }
 
     private ResponseProcessingStage find(final HttpContext context) {

--- a/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LimitedResponseSizeTest.java
+++ b/logbook-httpclient5/src/test/java/org/zalando/logbook/httpclient5/LimitedResponseSizeTest.java
@@ -1,0 +1,86 @@
+package org.zalando.logbook.httpclient5;
+
+import com.github.restdriver.clientdriver.ClientDriver;
+import com.github.restdriver.clientdriver.ClientDriverFactory;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.zalando.logbook.Correlation;
+import org.zalando.logbook.DefaultHttpLogFormatter;
+import org.zalando.logbook.DefaultSink;
+import org.zalando.logbook.HttpLogWriter;
+import org.zalando.logbook.Logbook;
+import org.zalando.logbook.TestStrategy;
+
+import java.io.IOException;
+
+import static com.github.restdriver.clientdriver.ClientDriverRequest.Method.GET;
+import static com.github.restdriver.clientdriver.RestClientDriver.giveResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LimitedResponseSizeTest {
+
+    private static final int MAX_RESPONSE_SIZE = 10;
+    final ClientDriver driver = new ClientDriverFactory().createClientDriver();
+
+    final HttpLogWriter writer = mock(HttpLogWriter.class);
+
+    protected final Logbook logbook = Logbook.builder()
+            .strategy(new TestStrategy())
+            .sink(new DefaultSink(new DefaultHttpLogFormatter(), writer))
+            .build();
+
+    private final CloseableHttpClient client = HttpClientBuilder.create()
+            .addRequestInterceptorFirst(new LogbookHttpRequestInterceptor(logbook))
+            .addResponseInterceptorFirst(new LogbookHttpResponseInterceptor(MAX_RESPONSE_SIZE))
+            .build();
+
+    @BeforeEach
+    void defaultBehaviour() {
+        when(writer.isActive()).thenReturn(true);
+    }
+
+    @AfterEach
+    void stop() throws IOException {
+        client.close();
+    }
+
+    @Test
+    void shouldLogRequestWithoutBody() throws IOException, ParseException {
+        driver.addExpectation(onRequestTo("/").withMethod(GET),
+                giveResponse("Hello, world!", "text/plain"));
+
+        final HttpGet request = new HttpGet(driver.getBaseUrl());
+
+        final CloseableHttpResponse response = client.execute(request);
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(response.getEntity()).isNotNull();
+        final String cappedResponse = "Hello, world!".substring(0, 10);
+        assertThat(EntityUtils.toString(response.getEntity())).isEqualTo(cappedResponse);
+
+        final String message = captureResponse();
+
+        assertThat(message)
+                .startsWith("Incoming Response:")
+                .contains("HTTP/1.1 200 OK", "Content-Type: text/plain", cappedResponse);
+    }
+
+    private String captureResponse() throws IOException {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(writer).write(any(Correlation.class), captor.capture());
+        return captor.getValue();
+    }
+}

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -499,25 +499,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>6.5.1</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
-                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                        <suppressionFiles>
-                            <suppressionFile>cve-suppressions.xml</suppressionFile>
-                        </suppressionFiles>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>3.2.4</version>

--- a/logbook-parent/pom.xml
+++ b/logbook-parent/pom.xml
@@ -35,7 +35,7 @@
         <json-path.version>2.7.0</json-path.version>
         <kotlin.version>1.6.10</kotlin.version>
         <ktor.version>1.6.7</ktor.version>
-        <netty.version>4.1.74.Final</netty.version>
+        <netty.version>4.1.82.Final</netty.version>
         <reactor-netty.version>1.0.14</reactor-netty.version>
         <slf4j.version>1.7.36</slf4j.version>
 
@@ -43,13 +43,13 @@
         <spring-boot1.version>1.5.22.RELEASE</spring-boot1.version>
         <spring-security4.version>4.2.20.RELEASE</spring-security4.version>
 
-        <spring5.version>5.3.16</spring5.version>
+        <spring5.version>5.3.23</spring5.version>
         <spring-boot2.version>2.6.4</spring-boot2.version>
-        <spring-security5.version>5.6.0</spring-security5.version>
+        <spring-security5.version>5.6.7</spring-security5.version>
 
-        <spring.version>5.3.16</spring.version>
+        <spring.version>5.3.23</spring.version>
         <spring-boot.version>2.6.4</spring-boot.version>
-        <spring-security.version>5.6.2</spring-security.version>
+        <spring-security.version>5.6.7</spring-security.version>
 
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.3.1</mockito.version>

--- a/logbook-spring/src/test/java/org/zalando/logbook/spring/RemoteResponseTest.java
+++ b/logbook-spring/src/test/java/org/zalando/logbook/spring/RemoteResponseTest.java
@@ -2,6 +2,7 @@ package org.zalando.logbook.spring;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.mock.http.client.MockClientHttpResponse;
 
 import java.io.IOException;
@@ -15,7 +16,7 @@ class RemoteResponseTest {
 
     @Test
     void statusCanThrow() throws IOException {
-        MockClientHttpResponse response = mock(MockClientHttpResponse.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
         when(response.getRawStatusCode()).thenThrow(new IOException("io exception"));
         assertThatThrownBy(() -> unit(response).getStatus()).hasMessageContaining("io exception");
     }
@@ -34,7 +35,7 @@ class RemoteResponseTest {
         return new MockClientHttpResponse("hello world".getBytes(), HttpStatus.OK);
     }
 
-    private org.zalando.logbook.HttpResponse unit(MockClientHttpResponse response) {
+    private org.zalando.logbook.HttpResponse unit(ClientHttpResponse response) {
         return new RemoteResponse(response);
     }
 }


### PR DESCRIPTION
This makes it possible to limit the number of bytes read from the response.

## Description
Logbook supports limiting the response size by truncating the response after it's been read. This still means that the full response is read into memory which could cause OOME issues.

This change makes it possible to only read the number of bytes that are needed, thus saving some memory.
I've limited the changes to the httpclient5 module to make the effort smaller.